### PR TITLE
feat: add initial support for bindings

### DIFF
--- a/packages/amgi-aiokafka/src/amgi_aiokafka/__init__.py
+++ b/packages/amgi-aiokafka/src/amgi_aiokafka/__init__.py
@@ -78,6 +78,7 @@ class _RecordsEvents:
             "id": message_receive_id,
             "headers": encoded_headers,
             "payload": record.value,
+            "bindings": {"kafka": {"key": record.key}},
             "more_messages": len(self._deque) != 0,
         }
         return message_receive_event
@@ -168,8 +169,13 @@ class Server:
     async def _message_send(self, event: MessageSendEvent) -> None:
         producer = await self._get_producer()
         encoded_headers = [(key.decode(), value) for key, value in event["headers"]]
+
+        key = event.get("bindings", {}).get("kafka", {}).get("key")
         await producer.send(
-            event["address"], headers=encoded_headers, value=event.get("payload")
+            event["address"],
+            headers=encoded_headers,
+            value=event.get("payload"),
+            key=key,
         )
 
     def stop(self) -> None:

--- a/packages/amgi-types/src/amgi_types/__init__.py
+++ b/packages/amgi-types/src/amgi_types/__init__.py
@@ -1,6 +1,7 @@
 import sys
 from collections.abc import Awaitable
 from collections.abc import Iterable
+from typing import Any
 from typing import Callable
 from typing import Literal
 from typing import Optional
@@ -60,6 +61,7 @@ class MessageReceiveEvent(TypedDict):
     id: str
     headers: Iterable[tuple[bytes, bytes]]
     payload: NotRequired[Optional[bytes]]
+    bindings: NotRequired[dict[str, dict[str, Any]]]
     more_messages: NotRequired[bool]
 
 
@@ -79,6 +81,7 @@ class MessageSendEvent(TypedDict):
     address: str
     headers: Iterable[tuple[bytes, bytes]]
     payload: NotRequired[Optional[bytes]]
+    bindings: NotRequired[dict[str, dict[str, Any]]]
 
 
 Scope = Union[MessageScope, LifespanScope]

--- a/packages/asyncfast/src/asyncfast/bindings.py
+++ b/packages/asyncfast/src/asyncfast/bindings.py
@@ -1,13 +1,14 @@
 from abc import ABC
-from collections.abc import Sequence
 from typing import ClassVar
 
 from pydantic.fields import FieldInfo
 
 
 class Binding(FieldInfo, ABC):
-    __path__: ClassVar[Sequence[str]]
+    __protocol__: ClassVar[str]
+    __field_name__: ClassVar[str]
 
 
 class KafkaKey(Binding):
-    __path__: ClassVar[Sequence[str]] = ("kafka", "key")
+    __protocol__ = "kafka"
+    __field_name__ = "key"

--- a/packages/asyncfast/src/asyncfast/bindings.py
+++ b/packages/asyncfast/src/asyncfast/bindings.py
@@ -1,0 +1,13 @@
+from abc import ABC
+from collections.abc import Sequence
+from typing import ClassVar
+
+from pydantic.fields import FieldInfo
+
+
+class Binding(FieldInfo, ABC):
+    __path__: ClassVar[Sequence[str]]
+
+
+class KafkaKey(Binding):
+    __path__: ClassVar[Sequence[str]] = ("kafka", "key")

--- a/packages/asyncfast/tests_asyncfast/test_message_object.py
+++ b/packages/asyncfast/tests_asyncfast/test_message_object.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from asyncfast import Header
 from asyncfast import Message
+from asyncfast.bindings import KafkaKey
 from pydantic import BaseModel
 
 
@@ -34,7 +35,6 @@ def test_message_header() -> None:
     assert dict(response) == {
         "address": "response_channel",
         "headers": [(b"id", b"100")],
-        "payload": None,
     }
 
 
@@ -48,7 +48,6 @@ def test_message_parameter() -> None:
     assert dict(response) == {
         "address": "register.ec5e9f87-c896-4fb1-b028-8352ef654e05",
         "headers": [],
-        "payload": None,
     }
 
 
@@ -62,5 +61,18 @@ def test_message_header_string() -> None:
     assert dict(response) == {
         "address": "response_channel",
         "headers": [(b"id", b"ec5e9f87-c896-4fb1-b028-8352ef654e05")],
-        "payload": None,
+    }
+
+
+def test_message_binding_kafka_key() -> None:
+    @dataclass
+    class Response(Message, address="response_channel"):
+        key: Annotated[UUID, KafkaKey()]
+
+    response = Response(key=UUID("ec5e9f87-c896-4fb1-b028-8352ef654e05"))
+
+    assert dict(response) == {
+        "address": "response_channel",
+        "bindings": {"kafka": {"key": b"ec5e9f87-c896-4fb1-b028-8352ef654e05"}},
+        "headers": [],
     }


### PR DESCRIPTION
bindings should allow for protocol specific properties to messages, a kafka key would be an example