### PR TITLE
fix(amgi-aiokafka): make test-utils a development dependency

### DIFF
--- a/packages/amgi-aiokafka/pyproject.toml
+++ b/packages/amgi-aiokafka/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
   "aiokafka>=0.12",
   "amgi-common==0.15.1",
   "amgi-types==0.15.1",
-  "test-utils",
 ]
 
 urls.Changelog = "https://github.com/asyncfast/amgi/blob/main/CHANGELOG.md"
@@ -40,6 +39,7 @@ entry-points.amgi_server.amgi-aiokafka = "amgi_aiokafka:_run_cli"
 
 [dependency-groups]
 dev = [
+  "test-utils",
   "testcontainers[kafka]>=4.13.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -133,11 +133,11 @@ dependencies = [
     { name = "aiokafka" },
     { name = "amgi-common" },
     { name = "amgi-types" },
-    { name = "test-utils" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "test-utils" },
     { name = "testcontainers", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9.2'" },
     { name = "testcontainers", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9.2'" },
 ]
@@ -147,11 +147,13 @@ requires-dist = [
     { name = "aiokafka", specifier = ">=0.12" },
     { name = "amgi-common", editable = "packages/amgi-common" },
     { name = "amgi-types", editable = "packages/amgi-types" },
-    { name = "test-utils", editable = "packages/test-utils" },
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "testcontainers", extras = ["kafka"], specifier = ">=4.13.0" }]
+dev = [
+    { name = "test-utils", editable = "packages/test-utils" },
+    { name = "testcontainers", extras = ["kafka"], specifier = ">=4.13.0" },
+]
 
 [[package]]
 name = "amgi-common"


### PR DESCRIPTION
this doesn't effect the functionality but [test-utils](https://pypi.org/project/test-utils/) was being pulled from pypi at install