### PR TITLE
fix(amgi-aiokafka): guard consumer fetch during rebalances to prevent concurrency issues

### DIFF
--- a/packages/amgi-aiokafka/src/amgi_aiokafka/__init__.py
+++ b/packages/amgi-aiokafka/src/amgi_aiokafka/__init__.py
@@ -1,12 +1,17 @@
 import asyncio
 import logging
 import sys
+from asyncio import Lock
+from collections.abc import AsyncIterable
+from collections.abc import AsyncIterator
 from collections.abc import Awaitable
 from collections.abc import Callable
 from types import TracebackType
 from typing import Any
 from typing import AsyncContextManager
 from typing import Literal
+from typing import TYPE_CHECKING
+from typing import TypeVar
 
 from aiokafka import AIOKafkaConsumer
 from aiokafka import AIOKafkaProducer
@@ -20,6 +25,16 @@ from amgi_types import AMGIReceiveEvent
 from amgi_types import AMGISendEvent
 from amgi_types import MessageScope
 from amgi_types import MessageSendEvent
+
+if TYPE_CHECKING:
+
+    class _ConsumerRebalanceListener: ...
+
+else:
+    from aiokafka import ConsumerRebalanceListener as _ConsumerRebalanceListener
+
+
+T = TypeVar("T")
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -131,6 +146,58 @@ class MessageSend:
         await self._producer.stop()
 
 
+class _HoldingLock:
+    def __init__(self, lock: Lock):
+        self._lock = lock
+        self._holding = False
+
+    def release(self) -> None:
+        if self._holding:
+            self._lock.release()
+            self._holding = False
+
+    async def acquire(self) -> None:
+        await self._lock.acquire()
+        self._holding = True
+
+
+async def _iter_with_lock(
+    iterable: AsyncIterable[T],
+    lock: Lock,
+) -> AsyncIterator[T]:
+    iterator = iterable.__aiter__()
+    holding_lock = _HoldingLock(lock)
+    try:
+        while True:
+            holding_lock.release()
+            await holding_lock.acquire()
+            try:
+                yield await iterator.__anext__()
+            except StopAsyncIteration:
+                break
+    finally:
+        holding_lock.release()
+
+
+class _RebalanceListener(_ConsumerRebalanceListener):
+    def __init__(self, rebalance_lock: Lock) -> None:
+        self._rebalance_lock = rebalance_lock
+
+    async def on_partitions_revoked(
+        self,
+        revoked: list[TopicPartition],
+    ) -> None:
+        async with self._rebalance_lock:
+            pass
+
+    async def on_partitions_assigned(
+        self,
+        assigned: list[TopicPartition],
+    ) -> None:
+        async with self._rebalance_lock:
+            pass
+
+
 class Server:
     _consumer: AIOKafkaConsumer
 
@@ -150,15 +217,19 @@ class Server:
         self._auto_offset_reset = auto_offset_reset
         self._message_send = message_send or MessageSend(bootstrap_servers)
         self._ackable_consumer = self._group_id is not None
+        self._rebalance_lock = Lock()
         self._stoppable = Stoppable()
 
     async def serve(self) -> None:
         self._consumer = AIOKafkaConsumer(
-            *self._topics,
             bootstrap_servers=self._bootstrap_servers,
             group_id=self._group_id,
             enable_auto_commit=False,
             auto_offset_reset=self._auto_offset_reset,
+        )
+        self._consumer.subscribe(
+            topics=list(self._topics),
+            listener=_RebalanceListener(self._rebalance_lock),
         )
         async with self._consumer, self._message_send as message_send:
             async with Lifespan(self._app) as state:
@@ -167,21 +238,19 @@ class Server:
     async def _main_loop(
         self, state: dict[str, Any], message_send: _MessageSendT
     ) -> None:
-        async for messages in self._stoppable.call(
-            self._consumer.getmany, timeout_ms=1000
+        async for messages in _iter_with_lock(
+            self._stoppable.call(self._consumer.getmany, timeout_ms=1000),
+            self._rebalance_lock,
         ):
             await asyncio.gather(
                 *[
-                    self._handle_partition_records(
-                        topic_partition, records, message_send, state
-                    )
+                    self._handle_partition_records(records, message_send, state)
                     for topic_partition, records in messages.items()
                 ]
             )
 
     async def _handle_partition_records(
         self,
-        topic_partition: TopicPartition,
         records: list[ConsumerRecord],
         message_send: _MessageSendT,
         state: dict[str, Any],

--- a/packages/amgi-aiokafka/src/amgi_aiokafka/__init__.py
+++ b/packages/amgi-aiokafka/src/amgi_aiokafka/__init__.py
@@ -1,17 +1,22 @@
 import asyncio
 import logging
 import sys
+from asyncio import Lock
+from asyncio import Task
 from collections.abc import Awaitable
 from collections.abc import Callable
 from types import TracebackType
 from typing import Any
 from typing import AsyncContextManager
 from typing import Literal
+from typing import TYPE_CHECKING
 
 from aiokafka import AIOKafkaConsumer
 from aiokafka import AIOKafkaProducer
+from aiokafka import ConsumerRebalanceListener
 from aiokafka import ConsumerRecord
 from aiokafka import TopicPartition
+from aiokafka.errors import CommitFailedError
 from amgi_common import Lifespan
 from amgi_common import server_serve
 from amgi_common import Stoppable
@@ -25,6 +30,15 @@ if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
+
+
+if TYPE_CHECKING:  # pragma: no cover
+
+    class _ConsumerRebalanceListener:
+        pass
+
+else:
+    _ConsumerRebalanceListener = ConsumerRebalanceListener
 
 _MessageSendT = Callable[[MessageSendEvent], Awaitable[None]]
 _MessageSendManagerT = AsyncContextManager[_MessageSendT]
@@ -78,26 +92,14 @@ async def _receive() -> AMGIReceiveEvent:
 class _Send:
     def __init__(
         self,
-        consumer: AIOKafkaConsumer,
-        record: ConsumerRecord,
-        ackable_consumer: bool,
         message_send: _MessageSendT,
     ) -> None:
-        self._consumer = consumer
         self._message_send = message_send
-        self._record = record
-        self._ackable_consumer = ackable_consumer
         self.acked = False
 
     async def __call__(self, event: AMGISendEvent) -> None:
         if event["type"] == "message.ack":
             self.acked = True
-            if self._ackable_consumer:
-                topic_partition = TopicPartition(
-                    self._record.topic, self._record.partition
-                )
-                offset = self._record.offset + 1
-                await self._consumer.commit({topic_partition: offset})
         if event["type"] == "message.send":
             await self._message_send(event)
 
@@ -131,9 +133,43 @@ class MessageSend:
         await self._producer.stop()
 
 
-class Server:
-    _consumer: AIOKafkaConsumer
+class _CancelListener(_ConsumerRebalanceListener):
+    def __init__(
+        self,
+        partition_lock: Lock,
+        partition_tasks: dict[TopicPartition, Task[None]],
+        assigned_partitions: set[TopicPartition],
+    ) -> None:
+        self._partition_lock = partition_lock
+        self._partition_tasks = partition_tasks
+        self._assigned_partitions = assigned_partitions
 
+    async def on_partitions_revoked(self, revoked: list[TopicPartition]) -> None:
+        async with self._partition_lock:
+            self._assigned_partitions.difference_update(revoked)
+            revoked_tasks = [
+                task
+                for topic_partition in revoked
+                if (task := self._partition_tasks.get(topic_partition)) is not None
+            ]
+        for revoked_task in revoked_tasks:
+            revoked_task.cancel()
+        results = await asyncio.gather(*revoked_tasks, return_exceptions=True)
+
+        for result in results:
+            if isinstance(result, asyncio.CancelledError):
+                continue
+            if isinstance(result, Exception):
+                logger.exception("Partition task failed during revoke", exc_info=result)
+            elif isinstance(result, BaseException):
+                raise result
+
+    async def on_partitions_assigned(self, assigned: list[TopicPartition]) -> None:
+        async with self._partition_lock:
+            self._assigned_partitions.update(assigned)
+
+
+class Server:
     def __init__(
         self,
         app: AMGIApplication,
@@ -149,46 +185,91 @@ class Server:
         self._group_id = group_id
         self._auto_offset_reset = auto_offset_reset
         self._message_send = message_send or MessageSend(bootstrap_servers)
-        self._ackable_consumer = self._group_id is not None
         self._stoppable = Stoppable()
+        self._partition_lock = Lock()
+        self._partition_tasks: dict[TopicPartition, Task[None]] = {}
+        self._assigned_partitions = set[TopicPartition]()
 
     async def serve(self) -> None:
-        self._consumer = AIOKafkaConsumer(
-            *self._topics,
+        consumer = AIOKafkaConsumer(
             bootstrap_servers=self._bootstrap_servers,
             group_id=self._group_id,
             enable_auto_commit=False,
             auto_offset_reset=self._auto_offset_reset,
         )
-        async with self._consumer, self._message_send as message_send:
+
+        consumer.subscribe(
+            self._topics,
+            listener=_CancelListener(
+                self._partition_lock, self._partition_tasks, self._assigned_partitions
+            ),
+        )
+        async with consumer, self._message_send as message_send:
             async with Lifespan(self._app) as state:
-                await self._main_loop(state, message_send)
+                await self._main_loop(consumer, state, message_send)
 
     async def _main_loop(
-        self, state: dict[str, Any], message_send: _MessageSendT
+        self,
+        consumer: AIOKafkaConsumer,
+        state: dict[str, Any],
+        message_send: _MessageSendT,
     ) -> None:
-        async for messages in self._stoppable.call(
-            self._consumer.getmany, timeout_ms=1000
-        ):
-            await asyncio.gather(
-                *[
-                    self._handle_partition_records(
-                        topic_partition, records, message_send, state
+        async for messages in self._stoppable.call(consumer.getmany, timeout_ms=1000):
+            async with self._partition_lock:
+                partition_tasks = {
+                    topic_partition: asyncio.create_task(
+                        self._handle_partition_records(
+                            consumer, topic_partition, records, message_send, state
+                        )
                     )
                     for topic_partition, records in messages.items()
-                ]
+                    if topic_partition in self._assigned_partitions
+                    or self._group_id is None
+                }
+
+                self._partition_tasks.update(partition_tasks)
+
+            results = await asyncio.gather(
+                *partition_tasks.values(), return_exceptions=True
             )
+
+            async with self._partition_lock:
+                self._partition_tasks.clear()
+
+            for result in results:
+                if isinstance(result, asyncio.CancelledError):
+                    continue
+                if isinstance(result, Exception):
+                    logger.exception("Partition task failed", exc_info=result)
+                elif isinstance(result, BaseException):
+                    raise result
 
     async def _handle_partition_records(
         self,
+        consumer: AIOKafkaConsumer,
         topic_partition: TopicPartition,
         records: list[ConsumerRecord],
         message_send: _MessageSendT,
         state: dict[str, Any],
     ) -> None:
-        for record in records:
-            if not await self._handle_record(record, message_send, state):
-                break
+        offset = None
+        try:
+            for record in records:
+                if await self._handle_record(record, message_send, state):
+                    offset = record.offset + 1
+                else:
+                    break
+        finally:
+            if self._group_id is not None and offset is not None:
+                try:
+                    await asyncio.shield(consumer.commit({topic_partition: offset}))
+                except CommitFailedError:
+                    logger.warning(
+                        "Commit failed for %s[%s] while committing offset %s",
+                        topic_partition.topic,
+                        topic_partition.partition,
+                        offset,
+                    )
 
     async def _handle_record(
         self,
@@ -209,9 +290,6 @@ class Server:
         }
 
         send = _Send(
-            self._consumer,
-            record,
-            self._ackable_consumer,
             message_send,
         )
         await self._app(

--- a/packages/amgi-aiokafka/tests_amgi_aiokafka/test_kafka_message.py
+++ b/packages/amgi-aiokafka/tests_amgi_aiokafka/test_kafka_message.py
@@ -1,13 +1,22 @@
+import asyncio
+import logging
+from asyncio import Lock
 from collections.abc import AsyncGenerator
 from typing import Generator
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
 from aiokafka import AIOKafkaConsumer
 from aiokafka import AIOKafkaProducer
+from aiokafka import TopicPartition
 from aiokafka.admin import AIOKafkaAdminClient
 from aiokafka.admin import NewTopic
+from aiokafka.errors import CommitFailedError
 from aiokafka.errors import TopicAlreadyExistsError
+from amgi_aiokafka import _CancelListener
 from amgi_aiokafka import _run_cli
 from amgi_aiokafka import run
 from amgi_aiokafka import Server
@@ -211,3 +220,121 @@ async def test_message_receive_not_callable(
     async with app.call() as (scope, receive, send):
         with pytest.raises(RuntimeError, match="Receive should not be called"):
             await receive()
+
+
+async def test_revoked_partition_task_cancellation_get_ignored() -> None:
+    mock_awaitable = AsyncMock(side_effect=asyncio.CancelledError)
+    cancel_listener = _CancelListener(
+        Lock(),
+        {TopicPartition("test", 0): asyncio.create_task(mock_awaitable())},
+        set(),
+    )
+
+    await cancel_listener.on_partitions_revoked([TopicPartition("test", 0)])
+
+
+async def test_revoked_partition_task_exception_gets_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_awaitable = AsyncMock(side_effect=Exception("error"))
+    partition_task = asyncio.create_task(mock_awaitable())
+    await asyncio.sleep(0)
+    cancel_listener = _CancelListener(
+        Lock(), {TopicPartition("test", 0): partition_task}, set()
+    )
+
+    with caplog.at_level(logging.ERROR, logger="amgi-aiokafka.error"):
+        await cancel_listener.on_partitions_revoked([TopicPartition("test", 0)])
+
+    assert any(
+        "Partition task failed during revoke" in record.message
+        for record in caplog.records
+    )
+
+
+async def test_revoked_partition_task_base_exception_is_raised() -> None:
+    base_exception = BaseException("error")
+    mock_awaitable = AsyncMock(side_effect=base_exception)
+    partition_task = asyncio.create_task(mock_awaitable())
+    await asyncio.sleep(0)
+    cancel_listener = _CancelListener(
+        Lock(), {TopicPartition("test", 0): partition_task}, set()
+    )
+
+    with pytest.raises(BaseException) as exc_info:
+        await cancel_listener.on_partitions_revoked([TopicPartition("test", 0)])
+
+    assert exc_info.value == base_exception
+
+
+async def test_main_loop_partition_task_cancellation_gets_ignored() -> None:
+    server = Server(MockApp(), "test", bootstrap_servers="unused", group_id=None)
+    mock_consumer = AsyncMock(spec=AIOKafkaConsumer)
+    mock_consumer.getmany.return_value = {TopicPartition("test", 0): [Mock()]}
+
+    async def cancel_partition(*args: object) -> None:
+        server.stop()
+        raise asyncio.CancelledError
+
+    with patch.object(
+        server, "_handle_partition_records", side_effect=cancel_partition
+    ):
+        await server._main_loop(mock_consumer, {}, AsyncMock())
+
+
+async def test_main_loop_partition_task_exception_gets_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    server = Server(MockApp(), "test", bootstrap_servers="unused", group_id=None)
+    mock_consumer = AsyncMock(spec=AIOKafkaConsumer)
+    mock_consumer.getmany.return_value = {TopicPartition("test", 0): [Mock()]}
+
+    async def fail_partition(*args: object) -> None:
+        server.stop()
+        raise Exception("error")
+
+    with (
+        patch.object(server, "_handle_partition_records", side_effect=fail_partition),
+        caplog.at_level(logging.ERROR, logger="amgi-aiokafka.error"),
+    ):
+        await server._main_loop(mock_consumer, {}, AsyncMock())
+
+    assert any("Partition task failed" in record.message for record in caplog.records)
+
+
+async def test_main_loop_partition_task_base_exception_gets_raised() -> None:
+    server = Server(MockApp(), "test", bootstrap_servers="unused", group_id=None)
+    mock_consumer = AsyncMock(spec=AIOKafkaConsumer)
+    mock_consumer.getmany.return_value = {TopicPartition("test", 0): [Mock()]}
+    base_exception = BaseException("error")
+
+    with (
+        patch.object(server, "_handle_partition_records", side_effect=base_exception),
+        pytest.raises(BaseException) as exc_info,
+    ):
+        await server._main_loop(mock_consumer, {}, AsyncMock())
+
+    assert exc_info.value == base_exception
+
+
+async def test_handle_partition_records_logs_commit_failed_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    server = Server(MockApp(), "test", bootstrap_servers="unused", group_id="test")
+    mock_consumer = AsyncMock(spec=AIOKafkaConsumer)
+    mock_consumer.commit.side_effect = CommitFailedError
+    mock_record = Mock()
+    mock_record.offset = 0
+
+    with (
+        patch.object(server, "_handle_record", return_value=True),
+        caplog.at_level(logging.WARNING, logger="amgi-aiokafka.error"),
+    ):
+        await server._handle_partition_records(
+            mock_consumer, TopicPartition("test", 0), [mock_record], AsyncMock(), {}
+        )
+
+    assert any(
+        "Commit failed for test[0] while committing offset 1" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
**Summary**
- Guard consumer fetch with a rebalance lock to prevent concurrent `getmany` during partition rebalances.
- Add a rebalance listener and an async iterator wrapper that acquires/releases the lock per batch.

**Why**
- Avoid concurrency issues when partitions are revoked/assigned while fetching.
