### PR TITLE
Feat/cloudevents message send log missing

### DIFF
--- a/packages/amgi-cloudevents/src/amgi_cloudevents/_run.py
+++ b/packages/amgi-cloudevents/src/amgi_cloudevents/_run.py
@@ -12,6 +12,7 @@ def run(
     message_send_endpoint: str | None = None,
     message_send_source: str = "/amgi-cloudevents",
     message_send_content_mode: ContentMode = "structured",
+    message_send_log_missing: bool = False,
 ) -> None:
     import uvicorn
 
@@ -24,4 +25,13 @@ def run(
         if message_send_endpoint is not None
         else None
     )
-    uvicorn.run(Server(app, path=path, message_send=message_send), host=host, port=port)
+    uvicorn.run(
+        Server(
+            app,
+            path=path,
+            message_send=message_send,
+            message_send_log_missing=message_send_log_missing,
+        ),
+        host=host,
+        port=port,
+    )

--- a/packages/amgi-cloudevents/src/amgi_cloudevents/_server.py
+++ b/packages/amgi-cloudevents/src/amgi_cloudevents/_server.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncIterator
 from collections.abc import Awaitable
 from collections.abc import Callable
@@ -25,17 +26,25 @@ from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
 
 _MessageSendT = Callable[[MessageSendEvent], Awaitable[None]]
 _MessageSendManagerT = AsyncContextManager[_MessageSendT]
+_logger = logging.getLogger("amgi-cloudevents.error")
 
 
 class MissingMessageSend:
+    def __init__(self, message_send_log_missing: bool) -> None:
+        self._message_send_log_missing = message_send_log_missing
+
     async def __aenter__(self) -> _MessageSendT:
         return self._send
 
     async def _send(self, event: MessageSendEvent) -> None:
-        raise RuntimeError(
+        send_error = (
             "CloudEvents message.send is not configured. Pass message_send to Server "
             "to allow AMGI handlers to send follow-up messages."
         )
+        if self._message_send_log_missing:
+            _logger.warning(send_error)
+        else:
+            raise RuntimeError(send_error)
 
     async def __aexit__(
         self,
@@ -92,10 +101,13 @@ class Server(Starlette):
         app: AMGIApplication,
         path: str = "/event",
         message_send: _MessageSendManagerT | None = None,
+        message_send_log_missing: bool = False,
     ) -> None:
         self._app = app
         self._state: dict[str, Any] = {}
-        self._message_send_context = message_send or MissingMessageSend()
+        self._message_send_context = message_send or MissingMessageSend(
+            message_send_log_missing=message_send_log_missing
+        )
         self._message_send: _MessageSendT | None = None
         super().__init__(
             routes=[Route(path, self._route, methods=["POST"])], lifespan=self._lifespan

--- a/packages/amgi-cloudevents/tests_amgi_cloudevents/test_server.py
+++ b/packages/amgi-cloudevents/tests_amgi_cloudevents/test_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import nullcontext
 from unittest.mock import AsyncMock
@@ -188,6 +189,33 @@ async def test_route_errors_when_message_send_is_not_configured(
 
     response = await response_task
     assert response.status_code == 204
+
+
+async def test_route_logs_missing_message_send_when_configured(
+    app: MockApp, caplog: pytest.LogCaptureFixture
+) -> None:
+    transport = ASGITransport(app=Server(app, message_send_log_missing=True))
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response_task = asyncio.create_task(_post_cloud_event(client))
+
+        with caplog.at_level(logging.WARNING, logger="amgi-cloudevents.error"):
+            async with app.call() as (scope, receive, send):
+                await send(
+                    {
+                        "type": "message.send",
+                        "address": "com.example.output",
+                        "headers": [],
+                        "payload": b"output",
+                    }
+                )
+
+        response = await response_task
+
+    assert response.status_code == 204
+    assert caplog.messages == [
+        "CloudEvents message.send is not configured. Pass message_send to Server "
+        "to allow AMGI handlers to send follow-up messages."
+    ]
 
 
 async def test_route_uses_configured_message_send(app: MockApp) -> None:

--- a/packages/asyncfast/src/asyncfast/_channel.py
+++ b/packages/asyncfast/src/asyncfast/_channel.py
@@ -8,6 +8,7 @@ from abc import abstractmethod
 from asyncio import AbstractEventLoop
 from asyncio import Task
 from collections.abc import AsyncGenerator
+from collections.abc import Awaitable
 from collections.abc import Callable
 from collections.abc import Generator
 from collections.abc import Mapping
@@ -44,6 +45,7 @@ P = ParamSpec("P")
 T = TypeVar("T")
 M = TypeVar("M", bound=Mapping[str, Any])
 DecoratedCallable = TypeVar("DecoratedCallable", bound=Callable[..., Any])
+MessageSendCallable = Callable[[MessageSendEvent], Awaitable[None]]
 
 
 def _next_or_stop(generator: Generator[T, None, Any]) -> T | StopIteration:
@@ -185,7 +187,7 @@ class HeaderResolver(TypeResolve[T]):
         return self.type_adapter.validate_python(value)
 
 
-async def send_message(send: AMGISendCallable, message: Mapping[str, Any]) -> None:
+async def send_message(send: MessageSendCallable, message: Mapping[str, Any]) -> None:
     message_send_event: MessageSendEvent = {
         "type": "message.send",
         "address": message["address"],
@@ -196,7 +198,7 @@ async def send_message(send: AMGISendCallable, message: Mapping[str, Any]) -> No
 
 
 class MessageSender(Generic[M]):
-    def __init__(self, send: AMGISendCallable) -> None:
+    def __init__(self, send: MessageSendCallable) -> None:
         self._send = send
 
     async def send(self, message: M) -> None:

--- a/packages/asyncfast/src/asyncfast/_channel.py
+++ b/packages/asyncfast/src/asyncfast/_channel.py
@@ -559,14 +559,6 @@ def get_channel(func: Callable[..., Any], address: str) -> Channel:
     if payloads > 1:
         raise InvalidChannelDefinitionError("Channel must have no more than 1 payload")
 
-    message_senders = sum(
-        isinstance(resolver, MessageSenderResolver) for _, resolver in resolvers
-    )
-    if message_senders > 1:
-        raise InvalidChannelDefinitionError(
-            "Channel must have no more than 1 message sender"
-        )
-
     if inspect.iscoroutinefunction(func):
         return AsyncChannel(func, resolvers, dependencies, address, address_parameters)
     if inspect.isasyncgenfunction(func):

--- a/packages/asyncfast/tests_asyncfast/test_errors.py
+++ b/packages/asyncfast/tests_asyncfast/test_errors.py
@@ -1,9 +1,6 @@
-from typing import Any
-
 import pytest
 from asyncfast import AsyncFast
 from asyncfast import InvalidChannelDefinitionError
-from asyncfast import MessageSender
 
 
 async def test_only_one_payload() -> None:
@@ -13,17 +10,4 @@ async def test_only_one_payload() -> None:
 
         @app.channel("topic")
         async def topic_handler(payload1: int, payload2: int) -> None:
-            pass  # pragma: no cover
-
-
-async def test_only_one_message_sender() -> None:
-    app = AsyncFast()
-
-    with pytest.raises(InvalidChannelDefinitionError):
-
-        @app.channel("topic")
-        async def topic_handler(
-            message_sender1: MessageSender[dict[str, Any]],
-            message_sender2: MessageSender[dict[str, Any]],
-        ) -> None:
             pass  # pragma: no cover


### PR DESCRIPTION
- feat(asyncfast): allow multiple message sender dependencies
- fix(asyncfast): narrow message sender send callable type
- feat(amgi-cloudevents): add option to log when missing send configuration
